### PR TITLE
ndk-18 bitrise-io version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitriseio/android-ndk:v2018_04_28-09_19-b981
+FROM bitriseio/android-ndk:v2018_09_29-05_48-b1194
 
 ## Install dependencies from apt
 RUN apt-get -y update && \


### PR DESCRIPTION
@CMBleakley 

[This](https://github.com/bitrise-io/android-ndk/blob/master/CHANGELOG.md#v2018_09_23_1) says 2018_09_23 is ndk-18, so I assume that [`v2018_09_29-05_48-b1194`](https://hub.docker.com/r/bitriseio/android-ndk/tags?page=2) uses ndk-18.